### PR TITLE
Fixes "hosts is not a legal parameter in an Ansible task".

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 
 - name: Update software packages
-  hosts: all
   sudo: True
   tasks:
     - name: update apt


### PR DESCRIPTION
Role should now contain `hosts` param.
