### PR TITLE
Fixes apt task: "tasks is not a legal parameter in an Ansible task".

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,4 @@
 
 - name: Update software packages
   sudo: True
-  tasks:
-    - name: update apt
-      apt: update_cache=yes cache_valid_time=3600
+  apt: update_cache=yes cache_valid_time=3600


### PR DESCRIPTION
Role should now contain `tasks` param.
