### PR TITLE
Readme spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ ntp_servers:
  - 0.amazon.pool.ntp.org iburst
  - 1.amazon.pool.ntp.org iburst
  - 2.amazon.pool.ntp.org iburst
- - 3.amazon.pool.ntp.org iburs
+ - 3.amazon.pool.ntp.org iburst
 ```
 
 If not specified, ntp package defaults will be used.


### PR DESCRIPTION
Fixes ntp_servers example.
